### PR TITLE
listen to inet_addr_any for docker

### DIFF
--- a/ReWeb/ReWeb__Config/ReWeb__Config.ml
+++ b/ReWeb/ReWeb__Config/ReWeb__Config.ml
@@ -63,7 +63,7 @@ module Default : S = struct
 
   let port = "port"
     |> int
-    |> Option.value ~default:(8080)
+    |> Option.value ~default:8080
 end
 (** Default values for ReWeb configuration settings. *)
 

--- a/ReWeb/ReWeb__Config/ReWeb__Config.ml
+++ b/ReWeb/ReWeb__Config/ReWeb__Config.ml
@@ -12,9 +12,9 @@
     that reads values from the system environment, by using the
     (type-safe) functions below. *)
 
-let string name = Sys.getenv_opt @@ "REWEB__" ^ name
+let string name = Sys.getenv_opt @@ name
 (** [string(name)] gets a value from the system environment variable
-    with the name [REWEB__name]. The following functions all use the
+    with the name [name]. The following functions all use the
     same name prefix and work for their specific types. *)
 
 let bool name = Option.bind (string name) bool_of_string_opt
@@ -23,7 +23,7 @@ let char name = Option.bind (string name) @@ function
   | "" -> None
   | string -> Some (String.unsafe_get string 0)
 (** [char(name)] gets the first character of the value of the system
-    environment variable named [REWEB__name]. *)
+    environment variable named [name]. *)
 
 let float name = Option.bind (string name) float_of_string_opt
 let int name = Option.bind (string name) int_of_string_opt
@@ -52,13 +52,13 @@ end
 
 module Default : S = struct
   module Filters = struct
-    let csp = "filters__csp" |> bool |> Option.value ~default:true
-    let hsts = "filters__hsts" |> bool |> Option.value ~default:true
+    let csp = "REWEB__filters__csp" |> bool |> Option.value ~default:true
+    let hsts = "REWEB__filters__hsts" |> bool |> Option.value ~default:true
   end
 
-  let secure = "secure" |> bool |> Option.value ~default:true
+  let secure = "REWEB__secure" |> bool |> Option.value ~default:true
 
-  let buf_size = "buf_size"
+  let buf_size = "REWEB__buf_size"
     |> int
     |> Option.value ~default:(Lwt_io.default_buffer_size ())
 

--- a/ReWeb/ReWeb__Config/ReWeb__Config.ml
+++ b/ReWeb/ReWeb__Config/ReWeb__Config.ml
@@ -46,6 +46,7 @@ module type S = sig
   (** Buffer size for internal string/bigstring handling. *)
 
   val port : int
+  (** Server port--default 8080 *)
 end
 (** The known ReWeb configuration settings. *)
 

--- a/ReWeb/ReWeb__Config/ReWeb__Config.ml
+++ b/ReWeb/ReWeb__Config/ReWeb__Config.ml
@@ -44,6 +44,9 @@ module type S = sig
 
   val buf_size : int
   (** Buffer size for internal string/bigstring handling. *)
+
+  val port : int
+  (** Server port--default 8080 *)
 end
 (** The known ReWeb configuration settings. *)
 
@@ -58,6 +61,10 @@ module Default : S = struct
   let buf_size = "buf_size"
     |> int
     |> Option.value ~default:(Lwt_io.default_buffer_size ())
+
+  let port = "port"
+    |> int
+    |> Option.value ~default:(8080)
 end
 (** Default values for ReWeb configuration settings. *)
 

--- a/ReWeb/ReWeb__Config/ReWeb__Config.ml
+++ b/ReWeb/ReWeb__Config/ReWeb__Config.ml
@@ -12,9 +12,9 @@
     that reads values from the system environment, by using the
     (type-safe) functions below. *)
 
-let string name = Sys.getenv_opt @@ name
+let string name = Sys.getenv_opt @@ "REWEB__" ^ name
 (** [string(name)] gets a value from the system environment variable
-    with the name [name]. The following functions all use the
+    with the name [REWEB__name]. The following functions all use the
     same name prefix and work for their specific types. *)
 
 let bool name = Option.bind (string name) bool_of_string_opt
@@ -23,7 +23,7 @@ let char name = Option.bind (string name) @@ function
   | "" -> None
   | string -> Some (String.unsafe_get string 0)
 (** [char(name)] gets the first character of the value of the system
-    environment variable named [name]. *)
+    environment variable named [REWEB__name]. *)
 
 let float name = Option.bind (string name) float_of_string_opt
 let int name = Option.bind (string name) int_of_string_opt
@@ -46,19 +46,18 @@ module type S = sig
   (** Buffer size for internal string/bigstring handling. *)
 
   val port : int
-  (** Server port--default 8080 *)
 end
 (** The known ReWeb configuration settings. *)
 
 module Default : S = struct
   module Filters = struct
-    let csp = "REWEB__filters__csp" |> bool |> Option.value ~default:true
-    let hsts = "REWEB__filters__hsts" |> bool |> Option.value ~default:true
+    let csp = "filters__csp" |> bool |> Option.value ~default:true
+    let hsts = "filters__hsts" |> bool |> Option.value ~default:true
   end
 
-  let secure = "REWEB__secure" |> bool |> Option.value ~default:true
+  let secure = "secure" |> bool |> Option.value ~default:true
 
-  let buf_size = "REWEB__buf_size"
+  let buf_size = "buf_size"
     |> int
     |> Option.value ~default:(Lwt_io.default_buffer_size ())
 

--- a/ReWeb/Server.ml
+++ b/ReWeb/Server.ml
@@ -204,7 +204,7 @@ let serve ~port server =
     ~request_handler
     ~error_handler
   in
-  let listen_addr = Unix.(ADDR_INET (inet_addr_loopback, port)) in
+  let listen_addr = Unix.(ADDR_INET (inet_addr_any, port)) in
   let open Let.Lwt in
   let* _ =
     Lwt_io.establish_server_with_client_socket listen_addr conn_handler

--- a/ReWeb/Server.ml
+++ b/ReWeb/Server.ml
@@ -213,5 +213,5 @@ let serve ~port server =
   let forever, _ = Lwt.wait () in
   forever
 
-let serve ?(port=8080) server = server |> serve ~port |> Lwt_main.run
+let serve ?(port=Config.Default.port) server = server |> serve ~port |> Lwt_main.run
 


### PR DESCRIPTION
address #16 

This is a WIP. I'm not sure what the goal about `REWEB__` prefixing by default is useful?

Having a `port` variable for example is something that many servers support.

Let me know what direction you want to go with this and I'll change the PR